### PR TITLE
Item Mover: Don't show category being moved

### DIFF
--- a/src/js/popups/item_mover/index.js
+++ b/src/js/popups/item_mover/index.js
@@ -95,7 +95,6 @@ class ItemMover extends Component {
    };
 
    handleMove = to => {
-      console.log('Moving to ', to);
       let { data, trailingPath, item } = this.props;
 
       // We need to also move everything nested under the current item.
@@ -150,6 +149,7 @@ class ItemMover extends Component {
                      data={this.props.data}
                      hideOptions
                      nonLeafOnly
+                     hiddenItem={item}
                      onChange={this.handleMove}
                   />
                </ExplorerContainer>

--- a/src/js/toolbox/components/explorer/explorer.js
+++ b/src/js/toolbox/components/explorer/explorer.js
@@ -18,7 +18,7 @@ const Container = styled.div`
 
 class Explorer extends Component {
    render() {
-      const { id, data, path, onChange, hideOptions } = this.props;
+      const { id, data, path, onChange, hiddenItem, hideOptions } = this.props;
 
       return (
          <Container
@@ -31,6 +31,7 @@ class Explorer extends Component {
                key={data}
                data={data}
                fullData={data}
+               hiddenItem={hiddenItem}
                hideOptions={hideOptions}
                leadingPath={path}
                onChange={onChange}
@@ -54,6 +55,7 @@ const RecursiveExplorer = ({
    fullData,
    leadingPath,
    trailingPath,
+   hiddenItem,
    hideOptions,
    onChange,
    pushPopup,
@@ -83,6 +85,7 @@ const RecursiveExplorer = ({
                            data: fullData,
                            leadingPath,
                            trailingPath,
+                           hiddenItem: name,
                            item: name,
                         },
                      }),
@@ -159,7 +162,7 @@ const RecursiveExplorer = ({
                const isAdmin = apiState.user.username === 'admin';
 
                return (
-                  name === 'tag' || (
+                  name === 'tag' || name === hiddenItem || (
                      <Item
                         key={name}
                         isSelected={isSelected}
@@ -206,6 +209,7 @@ const RecursiveExplorer = ({
                data={data[leadingPath[0]]}
                leadingPath={leadingPath.slice(1)}
                trailingPath={trailingPath.concat(leadingPath.slice(0, 1))}
+               hiddenItem={hiddenItem}
                hideOptions={hideOptions}
                onChange={onChange}
             />

--- a/src/js/toolbox/components/explorer/index.js
+++ b/src/js/toolbox/components/explorer/index.js
@@ -1,11 +1,11 @@
-import React, { Component } from "react";
-import styled from "styled-components";
-import Fuse from "fuse.js";
-import Explorer from "./explorer";
-import Search from "./search";
-import { Button } from "../../";
-import constants from "../../constants";
-import { minBy } from "lodash";
+import React, { Component } from 'react';
+import styled from 'styled-components';
+import Fuse from 'fuse.js';
+import Explorer from './explorer';
+import Search from './search';
+import { Button } from '../../';
+import constants from '../../constants';
+import { minBy } from 'lodash';
 
 const { color } = constants;
 
@@ -37,7 +37,7 @@ class ExplorerComponent extends Component {
       super(props);
       this.state = {
          path: [],
-         canSelect: false
+         canSelect: false,
       };
    }
 
@@ -45,7 +45,7 @@ class ExplorerComponent extends Component {
       const item = {
          itemName,
          path,
-         pathText: path.join(" ")
+         pathText: path.join(' '),
       };
 
       if (!tree) {
@@ -62,7 +62,7 @@ class ExplorerComponent extends Component {
 
       // Recursively create a list of items for each child.
       const childItems = Object.keys(tree).map(itemName => {
-         const childTree = itemName === "tag" ? false : tree[itemName];
+         const childTree = itemName === 'tag' ? false : tree[itemName];
          const childPath = [...path, itemName];
          return this.createItemList(childTree, itemName, childPath);
       });
@@ -77,26 +77,26 @@ class ExplorerComponent extends Component {
       const fuse = new Fuse(this.itemList, {
          keys: [
             {
-               name: "itemName",
-               weight: 0.3
+               name: 'itemName',
+               weight: 0.3,
             },
             {
-               name: "pathText",
-               weight: 0.7
-            }
+               name: 'pathText',
+               weight: 0.7,
+            },
          ],
          includeScore: true,
-         threshold: 0.4
+         threshold: 0.4,
       });
       const bestResult = minBy(
          fuse.search(str.trim()),
          result =>
             // Prefer more general categories (which have a smaller path length).
-            result.score * (1 + 0.1 * result.item.path.length)
+            result.score * (1 + 0.1 * result.item.path.length),
       );
 
       return {
-         path: bestResult ? bestResult.item.path : []
+         path: bestResult ? bestResult.item.path : [],
       };
    };
 
@@ -104,7 +104,7 @@ class ExplorerComponent extends Component {
       const { id } = this.props;
       this.setState({
          path,
-         leafSelected: this.checkForLeaf(path)
+         leafSelected: this.checkForLeaf(path),
       });
 
       const el = document.getElementById(`explorer-${id}`);
@@ -112,7 +112,7 @@ class ExplorerComponent extends Component {
          el.scroll({
             top: 0,
             left: el.scrollWidth,
-            behavior: "smooth"
+            behavior: 'smooth',
          });
       }, 100);
    };
@@ -138,7 +138,14 @@ class ExplorerComponent extends Component {
    };
 
    render() {
-      const { id, width, height, hideOptions, nonLeafOnly } = this.props;
+      const {
+         id,
+         width,
+         height,
+         hiddenItem,
+         hideOptions,
+         nonLeafOnly,
+      } = this.props;
       const { leafSelected, path } = this.state;
       const curItem = path[path.length - 1];
 
@@ -149,15 +156,17 @@ class ExplorerComponent extends Component {
                id={`explorer-${id}`}
                data={this.props.data}
                path={this.state.path}
+               hiddenItem={hiddenItem}
                hideOptions={hideOptions}
                onChange={this.updatePath}
             />
             <ActionButtonContainer>
                <Button
-               disabled={nonLeafOnly ? !curItem || leafSelected : !leafSelected}
+                  disabled={
+                     nonLeafOnly ? !curItem || leafSelected : !leafSelected
+                  }
                   onClick={() => this.props.onChange(path)}
-                  design="primary"
-               >
+                  design="primary">
                   Select
                </Button>
             </ActionButtonContainer>
@@ -168,7 +177,7 @@ class ExplorerComponent extends Component {
 
 ExplorerComponent.defaultProps = {
    nonLeafOnly: false,
-   onChange: () => {}
-}
+   onChange: () => {},
+};
 
 export default ExplorerComponent;


### PR DESCRIPTION
![Screen Shot 2019-04-14 at 4 48 34 PM](https://user-images.githubusercontent.com/21055469/56101057-2ac35480-5ed5-11e9-9d4d-6f7d1ef04c62.png)

## Details
We don't want, say, the "Ancestry" category to be moved into itself (this crashes the program).

This pull hides the currently selected category from the potential directories it can be moved to.