### PR TITLE
Download: Alerting the user that CSV file format download is currently unavailable

### DIFF
--- a/src/js/popups/download_manager/index.js
+++ b/src/js/popups/download_manager/index.js
@@ -151,6 +151,7 @@ class DownloadManager extends Component {
    };
 
    downloadCsv = () => {
+      alert("Sorry, this is currently unavailable. We are still implementing this function.");
       this.props.popPopup();
    };
 
@@ -181,7 +182,7 @@ class DownloadManager extends Component {
                   <Button
                      design="primary"
                      disabled={text.length === 0}
-                     onClick={this.downloadJson}>
+                     onClick={this.downloadCsv}>
                      Download CSV
                   </Button>
                   <Button


### PR DESCRIPTION
Download: Alerting the user that CSV file format download is currently unavailable
Fixing the bug where clicking the CSV format in will download as a JSON file. 