### PR TITLE
Create deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Running 'npm run build'..."
+eval npm run build > /dev/null
+echo "Copying files to production server..."
+eval scp -r -i ~/Documents/dev/flash/flashKeyPair.pem  build/* ec2-user@ec2-52-87-177-238.compute-1.amazonaws.com:/var/www/html/ > /dev/null

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flash",
   "version": "0.1.0",
   "private": true,
-  "homepage": "http://tannerv.com/MarkLogic",
+  "homepage": "http://ec2-18-212-13-61.compute-1.amazonaws.com/",
   "dependencies": {
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.10.0",


### PR DESCRIPTION
We can now run `./deploy.sh` to create a production build of the frontend and scp it to the server.