### PR TITLE
Explorer search bar: Fix squeezed height

### DIFF
--- a/src/js/toolbox/components/explorer/search.js
+++ b/src/js/toolbox/components/explorer/search.js
@@ -5,7 +5,7 @@ import { Icon } from "../../";
 const Container = styled.div`
    display: flex;
    align-items: center;
-   height: 4em;
+   min-height: 50px;
    box-sizing: border-box;
 `;
 


### PR DESCRIPTION
The search bar wasn't its full height on some browsers. This adds a min-height.