### PR TITLE
Use the source key in the preview data

### DIFF
--- a/src/js/toolbox/components/explorer/preview.js
+++ b/src/js/toolbox/components/explorer/preview.js
@@ -69,7 +69,7 @@ class Preview extends Component {
             <TextContainer>
                <Title>{category}</Title>
                <Subtitle>Value: <b>{value}</b></Subtitle>
-               <Subtitle><em>From healthcare.csv</em></Subtitle>
+               <Subtitle><em>From {data[0].source}</em></Subtitle>
             </TextContainer>
             {data.map(
                item =>


### PR DESCRIPTION
The backend now includes the CSV filename in the leaf nodes. This pull utilizes that info to display the file source in the preview