### PR TITLE
Visualizer: Remove edit capability

### DIFF
--- a/src/js/toolbox/components/explorer/explorer.js
+++ b/src/js/toolbox/components/explorer/explorer.js
@@ -154,7 +154,7 @@ const RecursiveExplorer = ({
             path={trailingPath}
             index={trailingPath.length}
             key={data}
-            showPlus
+            showPlus={!hideOptions}
             tag={data.tag}>
             {Object.keys(data).sort().map(name => {
                const isSelected = name === leadingPath[0];

--- a/src/js/views/visualizer/index.js
+++ b/src/js/views/visualizer/index.js
@@ -88,6 +88,7 @@ class VisualizerView extends Component {
                   key={`visualizer-${refreshCount}`}
                   id={1}
                   data={data}
+                  hideOptions
                   actionButtons={
                      <Button design="primary" onClick={this.downloadJson}>
                         {'Export...'}


### PR DESCRIPTION
On the final screen (after we've uploaded the modified data), we don't want users to be able to edit it. This pull removes the on-hover options as well as the "+" icon in each column that allows users to add a new item.